### PR TITLE
Update fastly crate to version 0.11.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +110,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fastly"
-version = "0.11.2"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52427cf825d145acbb8c30198df4df0d9ac34b3b727d006a42c648393bb5f73b"
+checksum = "2b2c298b27a94ac3747165fc964af1fc75908dd07c9b742c5576351b295ecec4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -121,6 +127,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_urlencoded",
  "sha2",
  "smallvec",
@@ -131,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-macros"
-version = "0.11.2"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dbd089072fd0c81a60cc280fa791d47f1d638bef920f4249c90bc8f1c17ea9"
+checksum = "1c596f4a2502dd04d5ae7983d7d37a8a8feab5a1a032d6932803dd34d1c1760d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -142,22 +149,24 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.11.2"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7472f43d72061834542e2f5dc11d3d2918fe7d06248c31decd893a614408d7c"
+checksum = "82277ec9cab41d300268389bc0936b6460b3846aa02b264510f86055e46d976d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "http",
 ]
 
 [[package]]
 name = "fastly-sys"
-version = "0.11.2"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b602c2dbe901ddf49e2c1a2fda9e335a15cda8d3bf442183f048bc4de25810e"
+checksum = "e6670559be2e7c7db47c6e102b86c613fc69f10715af399dae3bc5baedc1ea70"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fastly-shared",
+ "wasip2",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -486,6 +495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +675,24 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ publish = false
 debug = 1
 
 [dependencies]
-fastly = "0.11.2"
+fastly = "0.11.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.107"


### PR DESCRIPTION
Bump fastly and related dependencies from 0.11.2 to 0.11.11 in Cargo.toml and Cargo.lock. This update also adds new dependencies such as bitflags 2.10.0, serde_repr, wasip2, and wit-bindgen, reflecting changes in the fastly ecosystem.